### PR TITLE
gui separation, observer for decorating plotter

### DIFF
--- a/src/main/java/edu/iis/powp/inkDriver/IController.java
+++ b/src/main/java/edu/iis/powp/inkDriver/IController.java
@@ -1,0 +1,5 @@
+package edu.iis.powp.inkDriver;
+
+public interface IController {
+    void updateValueInController(float value);
+}

--- a/src/main/java/edu/iis/powp/inkDriver/IGui.java
+++ b/src/main/java/edu/iis/powp/inkDriver/IGui.java
@@ -1,0 +1,6 @@
+package edu.iis.powp.inkDriver;
+
+public interface IGui {
+    void updateValueInGui(float value);
+    void informationPopUp();
+}

--- a/src/main/java/edu/iis/powp/inkDriver/IGuiLogic.java
+++ b/src/main/java/edu/iis/powp/inkDriver/IGuiLogic.java
@@ -1,0 +1,9 @@
+package edu.iis.powp.inkDriver;
+
+public interface IGuiLogic {
+    void updateValueInGui(float value);
+    void fillInk();
+    void injectInkControl();
+    void informationPopUp();
+    void setGui(IGui gui);
+}

--- a/src/main/java/edu/iis/powp/inkDriver/InkController.java
+++ b/src/main/java/edu/iis/powp/inkDriver/InkController.java
@@ -6,10 +6,10 @@ import edu.kis.powp.drawer.shape.ILine;
 import edu.kis.powp.drawer.shape.LineFactory;
 
 
-public class InkController implements IPlotter, InkGuiUpdater {
+public class InkController implements IPlotter, IController {
 
     private IPlotter plotter;
-    private InkGui inkGui = InkGui.getInstance();
+    private IGuiLogic iGuiLogic;
     private ILine defaultLine;
 
     private float amountOfInk, tempAmountOfInk;
@@ -18,24 +18,26 @@ public class InkController implements IPlotter, InkGuiUpdater {
     private boolean isCriticalCharged = false;
 
     @Override
-    public void updateValue(float value) {
+    public void updateValueInController(float value) {
         amountOfInk = value;
         tempAmountOfInk = value;
-        inkGui.updateValue(amountOfInk);
+        iGuiLogic.updateValueInGui(amountOfInk);
         enoughInk = true;
     }
 
-    public InkController(IPlotter plotter, float amountOfInk){
+    public InkController(IPlotter plotter, float amountOfInk, IGuiLogic iGuiLogic){
         this.plotter = plotter;
         this.amountOfInk = amountOfInk;
         this.tempAmountOfInk = amountOfInk;
         defaultLine = ((LineAdapterPlotterDriver)plotter).getLine();
+        this.iGuiLogic = iGuiLogic;
     }
 
-    public InkController(IPlotter plotter, float amountOfInk, boolean forceStopAndAlert){
+    public InkController(IPlotter plotter, float amountOfInk, IGuiLogic iGuiLogic, boolean forceStopAndAlert){
         this.plotter = plotter;
         this.amountOfInk = amountOfInk;
         this.tempAmountOfInk = amountOfInk;
+        this.iGuiLogic = iGuiLogic;
         this.isCriticalCharged = forceStopAndAlert;
     }
 
@@ -67,9 +69,9 @@ public class InkController implements IPlotter, InkGuiUpdater {
 
     public boolean isEnoughInk(int x, int y){
         if((tempAmountOfInk - Math.sqrt(Math.pow((posX - x), 2) + Math.pow(posY - y, 2)))<0){
-            inkGui.informationPopUp();
+            iGuiLogic.informationPopUp();
             enoughInk = false;
-            inkGui.updateValue(amountOfInk);
+            iGuiLogic.updateValueInGui(amountOfInk);
         }
         return enoughInk;
     }
@@ -79,13 +81,13 @@ public class InkController implements IPlotter, InkGuiUpdater {
         {
             amountOfInk = tempAmountOfInk;
             plotter.drawTo(x, y);
-            inkGui.updateValue(amountOfInk);
+            iGuiLogic.updateValueInGui(amountOfInk);
         }
         else
         {
-            inkGui.informationPopUp();
+            iGuiLogic.informationPopUp();
             enoughInk = false;
-            inkGui.updateValue(amountOfInk);
+            iGuiLogic.updateValueInGui(amountOfInk);
         }
     }
 
@@ -95,13 +97,13 @@ public class InkController implements IPlotter, InkGuiUpdater {
             ((LineAdapterPlotterDriver)plotter).setLine(defaultLine);
             amountOfInk = tempAmountOfInk;
             plotter.drawTo(x, y);
-            inkGui.updateValue(amountOfInk);
+            iGuiLogic.updateValueInGui(amountOfInk);
         }
         else
         {
             ((LineAdapterPlotterDriver)plotter).setLine(LineFactory.getDottedLine());
             plotter.drawTo(x, y);
-            inkGui.updateValue(amountOfInk);
+            iGuiLogic.updateValueInGui(amountOfInk);
         }
     }
 

--- a/src/main/java/edu/iis/powp/inkDriver/InkControllerWithCriticalCharge.java
+++ b/src/main/java/edu/iis/powp/inkDriver/InkControllerWithCriticalCharge.java
@@ -7,29 +7,31 @@ import edu.iis.powp.command.SetPositionCommand;
 
 import java.util.ArrayList;
 
-public class InkControllerWithCriticalCharge implements IPlotter, InkGuiUpdater, IPlotterCommand {
+public class InkControllerWithCriticalCharge implements IPlotter, IController, IPlotterCommand {
 
     private ArrayList<IPlotterCommand> commandList = new ArrayList<>();
     private ArrayList<IPlotterCommand> executedCommandList = new ArrayList<>();
 
-    private InkController plotter;
+    private InkController inkController;
+    private InkGuiLogic inkGuiLogic;
 
-    public InkControllerWithCriticalCharge(IPlotter plotter, float amountOfInk){
-        this.plotter = new InkController(plotter, amountOfInk, true);
+    public InkControllerWithCriticalCharge(IPlotter plotter, float amountOfInk, InkGuiLogic inkGuiLogic){
+        this.inkGuiLogic = inkGuiLogic;
+        this.inkController = new InkController(plotter, amountOfInk, inkGuiLogic,true);
     }
 
     @Override
     public void setPosition(int x, int y) {
-        if(plotter.isEnoughInk())
-            plotter.setPosition(x,y);
+        if(inkController.isEnoughInk())
+            inkController.setPosition(x,y);
         else
             commandList.add(new SetPositionCommand(x,y));
     }
 
     @Override
     public void drawTo(int x, int y) {
-        if(plotter.isEnoughInk(x,y))
-            plotter.drawTo(x,y);
+        if(inkController.isEnoughInk(x,y))
+            inkController.drawTo(x,y);
         else
             commandList.add(new DrawToCommand(x,y));
     }
@@ -39,7 +41,7 @@ public class InkControllerWithCriticalCharge implements IPlotter, InkGuiUpdater,
         for(IPlotterCommand command : commandList){
             command.execute(driver);
             executedCommandList.add(command);
-            if(!plotter.isEnoughInk()) {
+            if(!inkController.isEnoughInk()) {
                 executedCommandList.remove(command);
                 break;
             }
@@ -49,8 +51,8 @@ public class InkControllerWithCriticalCharge implements IPlotter, InkGuiUpdater,
     }
 
     @Override
-    public void updateValue(float value) {
-        plotter.updateValue(value);
-        this.execute(plotter);
+    public void updateValueInController(float value) {
+        inkController.updateValueInController(value);
+        this.execute(inkController);
     }
 }

--- a/src/main/java/edu/iis/powp/inkDriver/InkGui.java
+++ b/src/main/java/edu/iis/powp/inkDriver/InkGui.java
@@ -9,19 +9,14 @@ import edu.iis.client.plottermagic.IPlotter;
 import edu.iis.powp.app.Application;
 import edu.iis.powp.app.gui.WindowComponent;
 
-public class InkGui extends JFrame implements WindowComponent{
+public class InkGui extends JFrame implements WindowComponent, IGui{
 
-    private static InkGui ourInstance = new InkGui();
-
-    private InkGuiUpdater inkGuiUpdater;
-    private Application application;
     private JTextField inkAmount;
-    private IPlotter currentPlotter;
     private JProgressBar progressBar;
 
-    boolean isShowedAlert = false;
+    public InkGui(IGuiLogic guiLogic) {
 
-    private InkGui() {
+        guiLogic.setGui(this);
         this.setTitle("Ink controller");
         this.setSize(400, 200);
         Container content = this.getContentPane();
@@ -48,7 +43,7 @@ public class InkGui extends JFrame implements WindowComponent{
         content.add(progressBar,c);
 
         JButton btnClearCommand = new JButton("Fill up");
-        btnClearCommand.addActionListener((ActionEvent e) -> fillInk());
+        btnClearCommand.addActionListener((ActionEvent e) -> guiLogic.fillInk());
         c.fill = GridBagConstraints.BOTH;
         c.weightx = 1;
         c.gridx = 0;
@@ -65,41 +60,14 @@ public class InkGui extends JFrame implements WindowComponent{
         }
     }
 
-    public void updateValue(float dane){
-        inkAmount.setText("Ink value:" + String.valueOf(dane));
-        progressBar.setValue((int)dane);
-    }
-
-    public void changePlotter(){
-        currentPlotter = application.getDriverManager().getCurrentPlotter();
-        inkGuiUpdater = (InkGuiUpdater) currentPlotter;
-    }
-
-    public void setApplication(Application application){
-        this.application = application;
-        currentPlotter = application.getDriverManager().getCurrentPlotter();
-        inkGuiUpdater = (InkGuiUpdater) currentPlotter;
-    }
-
-    public static InkGui getInstance() {
-        return ourInstance;
-    }
-
-    public void setInitialInkLvl(double initialInkLvl){
-        progressBar.setValue((int)initialInkLvl);
-        inkAmount.setText("Ink value:" + String.valueOf(initialInkLvl));
-    }
-
+    @Override
     public void informationPopUp(){
-        if(!isShowedAlert) {
-            JOptionPane.showMessageDialog(ourInstance, "Low Ink Level!", "Ink Level Warning", JOptionPane.WARNING_MESSAGE);
-            isShowedAlert = true;
-        }
+        JOptionPane.showMessageDialog(this, "Low Ink Level!", "Ink Level Warning", JOptionPane.WARNING_MESSAGE);
     }
 
-    public void fillInk(){
-        isShowedAlert = false;
-        inkGuiUpdater.updateValue(500);
+    @Override
+    public void updateValueInGui(float value) {
+        inkAmount.setText("Ink value:" + String.valueOf(value));
+        progressBar.setValue((int)value);
     }
-
 }

--- a/src/main/java/edu/iis/powp/inkDriver/InkGuiLogic.java
+++ b/src/main/java/edu/iis/powp/inkDriver/InkGuiLogic.java
@@ -1,0 +1,66 @@
+package edu.iis.powp.inkDriver;
+
+import edu.iis.client.plottermagic.IPlotter;
+import edu.iis.powp.app.Application;
+
+public class InkGuiLogic implements IGuiLogic {
+
+    private IController IController;
+    private Application application;
+    private IPlotter currentPlotter;
+    private IGui gui;
+    private boolean isShowedAlert = false;
+    private float initialInkLvl;
+
+    @Override
+    public void updateValueInGui(float value) {
+        gui.updateValueInGui(value);
+    }
+
+    @Override
+    public void fillInk(){
+        isShowedAlert = false;
+        IController.updateValueInController(500);//TO FIX STATIC VALUE
+        gui.updateValueInGui(500);
+    }
+
+    @Override
+    public void injectInkControl(){
+        try {
+            IPlotter plotter = new InkController(application.getDriverManager().getCurrentPlotter(), initialInkLvl, this);
+            application.getDriverManager().setCurrentPlotter(plotter);
+            IController = (IController) plotter;
+        }
+        catch (ClassCastException ex){
+            //user probably want assign controller for real plotter
+            IPlotter plotter = new InkController(application.getDriverManager().getCurrentPlotter(), initialInkLvl, this, true);
+            application.getDriverManager().setCurrentPlotter(plotter);
+            IController = (IController) plotter;
+        }
+    }
+
+    @Override
+    public void informationPopUp() {
+        if(!isShowedAlert){
+            gui.informationPopUp();
+            isShowedAlert = true;
+        }
+    }
+
+    @Override
+    public void setGui(IGui gui) {
+        this.gui = gui;
+    }
+
+    public void setInitialInkLvl(float initialInkLvl){
+        this.initialInkLvl = initialInkLvl;
+        updateValueInGui(initialInkLvl);
+    }
+
+    public void setApplication(Application application){
+        this.application = application;
+        //hack to run injectInkControl()
+        currentPlotter = application.getDriverManager().getCurrentPlotter();
+        application.getDriverManager().setCurrentPlotter(currentPlotter);
+    }
+}

--- a/src/main/java/edu/iis/powp/inkDriver/InkGuiObserver.java
+++ b/src/main/java/edu/iis/powp/inkDriver/InkGuiObserver.java
@@ -4,16 +4,16 @@ import edu.iis.powp.observer.Subscriber;
 
 public class InkGuiObserver implements Subscriber {
 
-    private InkGui inkGuiWindow;
+    private IGuiLogic guiLogic;
 
-    public InkGuiObserver(InkGui inkGuiWindow) {
+    public InkGuiObserver(IGuiLogic inkGuiWindow) {
         super();
-        this.inkGuiWindow = inkGuiWindow;
+        this.guiLogic = inkGuiWindow;
     }
 
     @Override
     public void update() {
-        inkGuiWindow.changePlotter();
+        guiLogic.injectInkControl();
     }
 
 }

--- a/src/main/java/edu/iis/powp/inkDriver/InkGuiUpdater.java
+++ b/src/main/java/edu/iis/powp/inkDriver/InkGuiUpdater.java
@@ -1,5 +1,0 @@
-package edu.iis.powp.inkDriver;
-
-public interface InkGuiUpdater {
-    void updateValue(float value);
-}

--- a/src/main/java/edu/iis/powp/inkDriver/InkSetup.java
+++ b/src/main/java/edu/iis/powp/inkDriver/InkSetup.java
@@ -1,0 +1,25 @@
+package edu.iis.powp.inkDriver;
+
+import edu.iis.client.plottermagic.IPlotter;
+import edu.iis.powp.app.Application;
+
+public class InkSetup {
+
+    private final static float INITIAL_INK_LVL = 400f;
+
+    public static void InkSetupDriver(Application application){
+        InkGuiLogic inkGuiLogic = new InkGuiLogic();
+
+        InkGui inkGui = new InkGui(inkGuiLogic);
+        inkGuiLogic.setInitialInkLvl(INITIAL_INK_LVL);
+        application.addWindowComponent("Ink controller", inkGui);
+
+        InkGuiObserver inkGuiObserver = new InkGuiObserver(inkGuiLogic);
+        application.getDriverManager().getChangePublisher().addSubscriber(inkGuiObserver);
+        inkGuiLogic.setApplication(application);
+
+        CommandEditor commandEditor = CommandEditor.getInstance();
+        commandEditor.setApplication(application);
+        application.addWindowComponent("Command Editor", commandEditor);
+    }
+}

--- a/src/test/java/edu/iis/powp/gui/TestPlotterApp.java
+++ b/src/test/java/edu/iis/powp/gui/TestPlotterApp.java
@@ -23,7 +23,6 @@ import edu.kis.powp.drawer.shape.LineFactory;
 
 public class TestPlotterApp {
 	private final static Logger logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
-	private final static float INITIAL_INK_LVL = 400f;
 
 	/**
 	 * Setup test concerning preset figures in context.
@@ -62,22 +61,14 @@ public class TestPlotterApp {
 	 */
 	private static void setupDrivers(Application application) {
 		IPlotter clientPlotter = new ClientPlotter();
-		//Plotter with ink controll and critical recharging
-		//drawing with the InkController is impossible due to the change of line style when ink is low
-		clientPlotter = new InkControllerWithCriticalCharge(clientPlotter, INITIAL_INK_LVL);
 		application.addDriver("Client Plotter", clientPlotter);
 
 		DrawPanelController drawerController = DrawerFeature.getDrawerController();
 		IPlotter plotter = new LineAdapterPlotterDriver(drawerController, LineFactory.getBasicLine(), "basic");
-
-		// Plotter with ink controll, will change line style when ink is low, we can add 3rd parameter as true, then we have a InkAlert with stopping
-		plotter = new InkController(plotter, INITIAL_INK_LVL);
 		application.addDriver("Line Simulator", plotter);
 		application.getDriverManager().setCurrentPlotter(plotter);
 
 		plotter = new LineAdapterPlotterDriver(drawerController, LineFactory.getSpecialLine(), "special");
-		//Plotter with ink controll and critical recharging, button "fill ink" will resume drawing
-		plotter = new InkControllerWithCriticalCharge(plotter, INITIAL_INK_LVL);
 		application.addDriver("Special line Simulator", plotter);
 		application.updateDriverInfo();
 	}
@@ -87,21 +78,9 @@ public class TestPlotterApp {
 		CommandManagerWindow commandManager = new CommandManagerWindow(CommandsFeature.getPlotterCommandManager());
 		application.addWindowComponent("Command Manager", commandManager);
 
-		InkGui inkGui = InkGui.getInstance();
-		inkGui.setInitialInkLvl(INITIAL_INK_LVL);
-		application.addWindowComponent("Ink controller", inkGui);
-
-		CommandEditor commandEditor = CommandEditor.getInstance();
-		commandEditor.setApplication(application);
-		application.addWindowComponent("Command Editor", commandEditor);
-
 		CommandManagerWindowCommandChangeObserver windowObserver = new CommandManagerWindowCommandChangeObserver(
 				commandManager);
 		CommandsFeature.getPlotterCommandManager().getChangePublisher().addSubscriber(windowObserver);
-
-		InkGuiObserver inkGuiObserver = new InkGuiObserver(inkGui);
-		application.getDriverManager().getChangePublisher().addSubscriber(inkGuiObserver);
-		inkGui.setApplication(application);
 	}
 
 	/**
@@ -134,12 +113,17 @@ public class TestPlotterApp {
 				DrawerFeature.setupDrawerPlugin(app);
 				CommandsFeature.setupCommandManager();
 
-				setupDrivers(app);
-				setupPresetTests(app);
-				setupCommandTests(app);
-				setupLogger(app);
-				setupWindows(app);
-
+				try {
+					setupDrivers(app);
+					setupPresetTests(app);
+					setupCommandTests(app);
+					setupLogger(app);
+					setupWindows(app);
+					InkSetup.InkSetupDriver(app);
+				}
+				catch (Exception ex){
+					ex.printStackTrace();
+				}
 				app.setVisibility(true);
 			}
 		});


### PR DESCRIPTION
FIXED:
- No seperation between GUI and logic (big class).
- FIX TO MERGE: Great deal of this code can be moved outside TestPlotterApp (only called within).
The goal is to seperate responsibilites and make merging for other groups easier.
- Lack of seperation between GUI and logic. Class, hard to understand.
- Hardwired functionality. The goal was to make it optional. If new driver will be added it cannot be automatically equipped with InkController decorator. It should be possible using observer pattern implemented in DriverManager.
- FIX TO MERGE: Direct dependency to GUI class